### PR TITLE
mark-devkit: Bump virtual/jre-21

### DIFF
--- a/virtual/jre/jre-21.ebuild
+++ b/virtual/jre/jre-21.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for Java Runtime Environment (JRE)"
+SLOT="${PV}"
+KEYWORDS="*"
+
+RDEPEND="|| (
+		virtual/jdk:${SLOT}
+		dev-java/oracle-jre-bin:${SLOT}[gentoo-vm(+)]
+		dev-java/openjdk-jre-bin:${SLOT}[gentoo-vm(+)]
+		dev-java/openjdk-jre:${SLOT}[gentoo-vm(+)]
+	)"


### PR DESCRIPTION
Automatic bump of package virtual/jre-21 for branch mark-unstable by mark-bot