### PR TITLE
mark-devkit: Bump virtual/jdk-21

### DIFF
--- a/virtual/jdk/jdk-21.ebuild
+++ b/virtual/jdk/jdk-21.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for Java Development Kit (JDK)"
+SLOT="${PV}"
+KEYWORDS="*"
+IUSE="headless-awt"
+
+RDEPEND="|| (
+		dev-java/oracle-jdk-bin:${SLOT}[gentoo-vm(+),headless-awt=]
+		dev-java/openjdk-bin:${SLOT}[gentoo-vm(+),headless-awt=]
+		dev-java/openjdk:${SLOT}[gentoo-vm(+),headless-awt=]
+	)"


### PR DESCRIPTION
Automatic bump of package virtual/jdk-21 for branch mark-unstable by mark-bot