### PR TITLE
mark-devkit: Bump dev-java/openjdk-jre-bin-11.0.26_p4

### DIFF
--- a/dev-java/openjdk-jre-bin/openjdk-jre-bin-11.0.26_p4.ebuild
+++ b/dev-java/openjdk-jre-bin/openjdk-jre-bin-11.0.26_p4.ebuild
@@ -1,0 +1,76 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit java-vm-2
+
+DESCRIPTION="Prebuilt Java JRE binaries provided by Eclipse Temurin"
+HOMEPAGE="https://adoptium.net"
+SRC_URI="
+	ppc64? ( https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.26%2B4/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.26_4.tar.gz -> OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.26_4.tar.gz )
+	arm64? ( https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.26%2B4/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.26_4.tar.gz -> OpenJDK11U-jre_aarch64_linux_hotspot_11.0.26_4.tar.gz )
+	amd64? ( https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.26%2B4/OpenJDK11U-jre_x64_linux_hotspot_11.0.26_4.tar.gz -> OpenJDK11U-jre_x64_linux_hotspot_11.0.26_4.tar.gz )
+	arm? ( https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.26%2B4/OpenJDK11U-jre_arm_linux_hotspot_11.0.26_4.tar.gz -> OpenJDK11U-jre_arm_linux_hotspot_11.0.26_4.tar.gz )"
+
+LICENSE="GPL-2-with-classpath-exception"
+KEYWORDS="-* amd64 arm arm64 ppc64"
+SLOT="$(ver_cut 1)"
+IUSE="alsa cups +gentoo-vm headless-awt selinux"
+
+RDEPEND="
+	media-libs/fontconfig:1.0
+	media-libs/freetype:2
+	>net-libs/libnet-1.1
+	>=sys-apps/baselayout-java-0.1.0-r1
+	>=sys-libs/glibc-2.2.5:*
+	sys-libs/zlib
+	alsa? ( media-libs/alsa-lib )
+	cups? ( net-print/cups )
+	selinux? ( sec-policy/selinux-java )
+	!headless-awt? (
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXi
+		x11-libs/libXrender
+		x11-libs/libXtst
+	)"
+
+RESTRICT="preserve-libs splitdebug"
+QA_PREBUILT="*"
+
+S="${WORKDIR}/jdk-11.0.26+4-jre"
+
+src_install() {
+	local dest="/opt/${PN}-${SLOT}"
+	local ddest="${ED}/${dest#/}"
+
+	# Not sure why they bundle this as it's commonly available and they
+	# only do so on x86_64. It's needed by libfontmanager.so. IcedTea
+	# also has an explicit dependency while Oracle seemingly dlopens it.
+	rm -vf lib/libfreetype.so || die
+
+	# Oracle and IcedTea have libjsoundalsa.so depending on
+	# libasound.so.2 but AdoptOpenJDK only has libjsound.so. Weird.
+	if ! use alsa ; then
+		rm -v lib/libjsound.* || die
+	fi
+
+	if use headless-awt ; then
+		rm -v lib/lib*{[jx]awt,splashscreen}* || die
+	fi
+
+	rm -v lib/security/cacerts || die
+	dosym ../../../../../etc/ssl/certs/java/cacerts "${dest}"/lib/security/cacerts
+
+	dodir "${dest}"
+	cp -pPR * "${ddest}" || die
+
+	java-vm_install-env "${FILESDIR}"/${PN}.env.sh
+	java-vm_set-pax-markings "${ddest}"
+	java-vm_revdep-mask
+	java-vm_sandbox-predict /dev/random /proc/self/coredump_filter
+}
+
+pkg_postinst() {
+	java-vm-2_pkg_postinst
+}


### PR DESCRIPTION
Automatic bump of package dev-java/openjdk-jre-bin-11.0.26_p4 for branch mark-xl by mark-bot