### PR TITLE
mark-devkit: Bump virtual/jre-1.8.0-r2

### DIFF
--- a/virtual/jre/jre-1.8.0-r2.ebuild
+++ b/virtual/jre/jre-1.8.0-r2.ebuild
@@ -1,0 +1,12 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="Virtual for Java Runtime Environment (JRE)"
+SLOT="1.8"
+KEYWORDS="*"
+
+RDEPEND="|| (
+		virtual/jdk:1.8
+		dev-java/openjdk-jre-bin:8[gentoo-vm(+)]
+	)"


### PR DESCRIPTION
Automatic bump of package virtual/jre-1.8.0-r2 for branch mark-iii by mark-bot