### PR TITLE
mark-devkit: Bump virtual/jdk-1.8.0-r5

### DIFF
--- a/virtual/jdk/jdk-1.8.0-r5.ebuild
+++ b/virtual/jdk/jdk-1.8.0-r5.ebuild
@@ -1,0 +1,15 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="Virtual for Java Development Kit (JDK)"
+SLOT="1.8"
+KEYWORDS="*"
+IUSE="headless-awt"
+
+RDEPEND="|| (
+		dev-java/icedtea-bin:8[headless-awt=]
+		dev-java/openjdk-bin:8[gentoo-vm(+),headless-awt=]
+		dev-java/icedtea:8[headless-awt=]
+		dev-java/openjdk:8[gentoo-vm(+),headless-awt=]
+	)"


### PR DESCRIPTION
Automatic bump of package virtual/jdk-1.8.0-r5 for branch mark-unstable by mark-bot