### PR TITLE
mark-devkit: Bump dev-java/javatoolkit-0.6.0-r2

### DIFF
--- a/dev-java/javatoolkit/javatoolkit-0.6.0-r2.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.6.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3+ )
+PYTHON_COMPAT=( python3_{5,6,7} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit distutils-r1 multilib prefix


### PR DESCRIPTION
Automatic bump of package dev-java/javatoolkit-0.6.0-r2 for branch mark-iii by mark-bot